### PR TITLE
Mappings for GP2040-CE controller DirectInput driver modes

### DIFF
--- a/default-device-mappings.lisp
+++ b/default-device-mappings.lisp
@@ -77,6 +77,30 @@
   :axes (0 :DPAD-H 1 :DPAD-V)
   :orientations (0 1.0 1 -1.0))
 
+(define-device-mapping (:DINPUT 3853 146)
+  :name "Hori Pokken Controller"
+  :icon-type :GENERIC-NINTENDO
+  :buttons (1 :A 2 :B 0 :X 3 :Y 4 :L1 6 :L2 10 :L3 5 :R1 7 :R2 11 :R3 8 :SELECT
+            12 :HOME 9 :START 13 :CAPTURE)
+  :axes (8 :DPAD-H 9 :DPAD-V)
+  :orientations NIL)
+
+(define-device-mapping (:DINPUT 4292 33472)
+  :name "Multi-Platform Gamepad GP2040-CE (D-Input)"
+  :icon-type :GENERIC-XBOX
+  :buttons (1 :A 2 :B 0 :X 3 :Y 4 :L1 6 :L2 10 :L3 5 :R1 7 :R2 11 :R3 8 :SELECT
+            9 :START 12 :HOME 13 :CAPTURE)
+  :axes (8 :DPAD-H 9 :DPAD-V)
+  :orientations NIL)
+
+(define-device-mapping (:DINPUT 5426 1025)
+  :name "Multi-Platform Gamepad GP2040-CE (PS4)"
+  :icon-type :GENERIC-PLAYSTATION
+  :buttons (1 :A 2 :B 0 :X 3 :Y 4 :L1 6 :L2 10 :L3 5 :R1 7 :R2 11 :R3 8 :SELECT
+            12 :HOME 9 :START 13 :CAPTURE)
+  :axes (3 :L2 4 :R2 8 :DPAD-H 9 :DPAD-V)
+  :orientations NIL)
+
 (define-device-mapping (:EVDEV 1118 654)
   :name "Microsoft X-Box 360 pad"
   :icon-type :GENERIC-XBOX

--- a/protocol.lisp
+++ b/protocol.lisp
@@ -9,7 +9,7 @@
                           :l1 :l2 :l3
                           :r1 :r2 :r3
                           :dpad-l :dpad-r :dpad-u :dpad-d
-                          :select :home :start
+                          :select :home :start :capture
                           :l-h :l-v :r-h :r-v
                           :dpad-h :dpad-v
                           :tilt-x :tilt-y :tilt-z
@@ -34,6 +34,7 @@
       :select "Left center button (select/share/minus)"
       :home "Middle center button (logo/home)"
       :start "Right center button (start/options/plus)"
+      :capture "Lower center button (capture/touchpad)"
       :l-h "Left stick horizontal axis"
       :l-v "Left stick vertical axis"
       :r-h "Right stick horizontal axis"


### PR DESCRIPTION
Mappings for the three Direct Input driver modes for [GP2040-CE](https://gp2040-ce.info/) firmware based controllers.

These include basic Direct Input mode, simply called D-Input, PS4 compatible mode, and Nintendo Switch compatible mode. The XInput mode works as is and the rest are based on its button mappings.

The Nintendo Switch mode pretends to be a Hori Pokken Tournament controller. I don't have an actual Pokken controller, nor could I find the product number of one documented anywhere, so I can only hope that these match.

The vendor numbers for the Direct Input and PS4 modes seem random. The former maps to "Silicon Laboratories, Inc." and the latter to "Razer (Asia-Pacific) Pte Ltd." Both provide the names as "GP2040-CE (x)" where x is either "D-Input" or "PS4" depending on the mode.

A slight oddity with the PS4 mode was that pressing the L2 or R2 causes both button event-press/release and an axis-move event to occurr.

The commit also includes an update to the protocol to include a button for the capture/touchpad button.